### PR TITLE
[BB-9504] docs: adds ADR 003 for implementing LearningPathEnrollment API

### DIFF
--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -56,7 +56,7 @@ Model attributes
 * ``role`` - ``CharField`` to store the role of the user creating the enrollment.
 * ``enrolled_email`` - ``CharField`` to store the email of the learner.
 * ``state_transition`` - ``CharField`` to store the enrollment state transition.
-  This field will use the existing `TRANSITION_STATES`_ from the LMS.
+  This field will use the same values as `TRANSITION_STATES`_ from the LMS.
 * ``reason`` - ``TextField`` to store reason for manual enrollment.
 * ``history`` - `django-simple-history`_ ``HistoricalRecords`` field
 
@@ -166,11 +166,8 @@ both self-unenrollment and staff-unenrollment.
 * Return a 404 when there are no active enrollments for the learner.
 
 This method will be gated with a Django settings ``LEARNING_PATHS_ALLOW_SELF_UNENROLLMENT``
-and ``LEARNING_PATHS_ALLOW_STAFF_UNENROLLMENT`` that will default to ``False`` and
-will have to be explicitly enabled.
+and will default to ``False`` and will have to be explicitly enabled.
 
-* When the ``LEARNING_PATHS_ALLOW_STAFF_UNENROLLMENT`` is ``False``, the ``is_active``
-  field will be marked as **read-only**, preventing staff from unenrolling learners.
 * When the ``LEARNING_PATHS_ALLOW_SELF_UNENROLLMENT`` is ``False``, DELETE requests
   from non-staff members will be returned HTTP 403.
 
@@ -211,15 +208,13 @@ The API will accept the following JSON data.
 
    {
      "learning_paths": "path-v1:ABC+XYZ+2025_Term1,path-v1:CC+DDD+2025_Term1",
-     "emails": "userA@example.com,new_user@example.com",
-     "reason": "reason for bulk enrollment"
+     "emails": "userA@example.com,new_user@example.com"
    }
 
 
 * `learning_paths` - a comma separated list of the Learning Path keys to enroll
   learner into
 * `emails` - a comma separated list of emails of the learners to enroll
-* `reason` - text explaining the reason for the bulk enrollment
 
 The API view filter out the invalid emails and Learning Path IDs before
 processing the enrollments. For all combination of valid Learning Paths and the
@@ -228,9 +223,7 @@ user emails, the following will be created:
 #. A ``LearningPathEnrollmentAllowed`` object - with users linked for existing
    users, and just the emails for non-existing users.
 #. A ``LearningPathEnrollment`` object for existing users.
-#. A ``ManualEnrollmentAudit`` object which captures all the necessary metadata
-   from the API call like ``enrolled_by`` user, ``reason`` and the relevant
-   ``state_transition``.
+
 
 7. User model post_save signal receiver for auto enrollment
 ===========================================================

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -265,7 +265,7 @@ inviting them.
 If a Learning Path is composed of courses that are restricted using this flag,
 either partially (some of the courses) or fully (all the courses), it creates
 a scenario where a learner might be enrolled in a Learning Path using the
-:ref:`Enroll API <enroll-api>`, but cannot enroll into a course that is a part
+:ref:`Enroll API <4-enroll-api>`, but cannot enroll into a course that is a part
 of the Learning Path.
 
 This limitation will be addressed in a future ADR, that could possibly introduce

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -118,6 +118,7 @@ creating an enrollment.
 While this will solve the issues where an user is enrolled in a Learning Path,
 but lacks access to the underlying courses at the time of enrollment, it is
 flawed in other scenarios like:
+
 * courses in a learning path are gated by pre-requisites like skills or
   completion of other courses
 * courses are marked as "invite only" but are available via their enterprise's

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -24,7 +24,7 @@ perform operations on the model.
 Decision
 ********
 
-We will create the following views in the ``api`` app to expose an API that can be called
+We will create the following views in the ``api`` package to expose an API that can be called
 by other services and MFEs.
 
 .. _enroll-api:
@@ -32,14 +32,14 @@ by other services and MFEs.
 1. Enroll API
 =============
 
-This API will allow learners to be enrolled in the
+This API will allow learners to be enrolled in the Learning Path.
 
 +---------------------+-------------------------------------------------------+
-| API Path            | /api/v1/learning-path-enrollment/                     |
+| API Path            | /api/v1/learning-path-enrollment/<learning_path_id>   |
 +---------------------+-------------------------------------------------------+
 | Methods             | GET, POST, DELETE                                     |
 +---------------------+-------------------------------------------------------+
-| Data                | learning_path_id (uuid), username (OPTIONAL)          |
+| Query Params        | username (OPTIONAL)                                   |
 +---------------------+-------------------------------------------------------+
 | Permissions Required| LoggedIn                                              |
 +---------------------+-------------------------------------------------------+
@@ -51,14 +51,21 @@ This API will allow learners to be enrolled in the
 GET
 """
 
-**Corresponding User Action:** Fetch my enrollment
+**Corresponding User Action:** Fetch enrollment in a Learning Path
 
-* The data fields ``learning_path_id`` and ``username`` will be passed as query
-  parameters.
-* Return the LearningPathEnrollment object if the logged-in user is enrolled in the
-  specified learning path. Otherwise returns a HTTP 404.
-* When the ``username`` is present, returns all the enrollments in a learning
-  path if the ``currentUser`` is a **staff** or **admin** user.
+* When the ``username`` query parameter is present, the api returns
+
+  * the *active* enrollment object of the corresponding user for a **staff** user
+    or when both ``currentUser`` and the ``username`` point to the same user.
+  * HTTP 403 for a non-staff user, when ``currentUser`` and ``username``
+    refer to different users.
+
+* When the ``username`` query parameter is absent, the api returns
+
+  * all the *active* enrollments in a Learning Path if the ``currentUser`` is a **staff**
+    or **admin** user.
+  * the ``LearningPathEnrollment`` object if the logged-in user is enrolled in the
+    specified learning path. Otherwise returns a HTTP 404.
 
 
 POST
@@ -68,9 +75,18 @@ POST
 
 * When ``username`` is absent, enrolls the ``currentUser`` in the Learning
   Path reference by the ``learning_path_id``.
-* When ``username`` is passed and is different from the ``currentUser``, the user
-  linked to ``username`` will be enrolled, if the ``currentUser`` is a **staff**
-  or **admin**. Otherwise, this will return an HTTP 403 error.
+* When ``username`` is present
+
+  * ``username`` is different from the ``currentUser``, the user
+    linked to ``username`` will be enrolled, if the ``currentUser`` is a
+    **staff** or **admin**.
+  * Return an HTTP 403 error if the ``currentUser`` is a non-staff user
+  * Return an HTTP 404 if the ``username`` or ``learning_path_id`` do not
+    resolve into valid objects.
+
+* When an *active* ``LearningPathEnrollment`` object exists for the user and the
+  Learning Path, return HTTP 409 Conflict.
+
 
 DELETE
 """"""
@@ -80,29 +96,79 @@ DELETE
 This will follow the same permission logic as the **POST** request allowing
 both self-unenrollment and staff-unenrollment.
 
+* Marks the *active* ``LearningPathEnrollment`` of the learner as inactive, by
+  setting the ``is_active`` field to ``False`` when the learner has an active
+  enrollment.
+* Return a 404 when there are no active enrollments for the learner.
 
-2. LearningPathEnrollment Model
+This method will be gated with a Django settings ``LEARNING_PATHS_ALLOW_SELF_UNENROLLMENT``
+and ``LEARNING_PATHS_ALLOW_STAFF_UNENROLLMENT`` that will default to ``False`` and
+will have to be explicitly enabled.
+
+* When the ``LEARNING_PATHS_ALLOW_STAFF_UNENROLLMENT`` is ``False``, the ``is_active``
+  field will be marked as **read-only**, preventing staff from unenrolling learners.
+* When the ``LEARNING_PATHS_ALLOW_SELF_UNENROLLMENT`` is ``False``, DELETE requests
+  from non-staff members will be returned HTTP 403.
+
+
+2. Fetch Enrollments API
+========================
+
+This API would list all the Learning Path enrollments
+
+* of the user making the request, for a non-staff user
+* of all users, for a staff user
+
++---------------------+-------------------------------------------------------+
+| API Path            | /api/v1/learning-path-enrollment/                     |
++---------------------+-------------------------------------------------------+
+| Methods             | GET                                                   |
++---------------------+-------------------------------------------------------+
+| Permissions Required| LoggedIn                                              |
++---------------------+-------------------------------------------------------+
+
+
+3. LearningPathEnrollment Model
 ===============================
 
-Add a new ``enrolled_by`` as a ``ForeignKey`` field to the
-``LearningPathEnrollment`` model that will store the user who created the
-enrollment. This will allow for distinguishing between self and staff
-enrollments.
+Introduce new fields to the ``LearningPathEnrollment`` model:
 
-Since it is already a subclass of the ``TimeStatmpedModel``, we don't need to
-introduce a ``enrolled_at`` field and can instead depend on the inherited ``created``
-field.
+#. ``is_active`` as a ``BooleanField`` that will indicate the enrolled/unenrolled
+   state of the learner.
+#. ``history`` as a `django-simple-history`_ ``HistoricalRecords`` field to preserve
+   the record of changes made on an enrollment.
+
+.. note::
+
+   Since it is already a subclass of the ``TimeStatmpedModel``, we don't need to
+   introduce a ``enrolled_at`` field and can instead depend on the inherited ``created``
+   field.
+
+
+.. _django-simple-history: https://django-simple-history.readthedocs.io/en/latest/quick_start.html
 
 Consequences
 ************
 
 * The new API will allow external services with valid user credentials (eg.,
   MFEs) to enroll learners in Learning Paths.
-* While access to courses can be restricted by marking them "Invitation
-  Required", there is no such flag for a Learning Path. So, any learner who
-  knows the ID of a Learning Path can enroll using the :ref:`Enroll API <enroll-api>`,
-  without having access to any of the courses in the Learning Path. This
-  shortcoming will have be addressed in future development.
+
+Dealing with "invitation-only" courses
+======================================
+
+Access to courses can be restricted by marking them as "invitation-only". This
+prevents learner from enrolling into courses without a staff member explicitly
+inviting them.
+
+If a Learning Path is composed of courses that are restricted using this flag,
+either partially (some of the courses) or fully (all the courses), it creates
+a scenario where a learner might be enrolled in a Learning Path using the
+:ref:`Enroll API <enroll-api>`, but cannot enroll into a course that is a part
+of the LearningPath.
+
+This limitation will be addressed in a future ADR, that could possibly introduce
+a flag on the ``LearningPath`` model allowing bypass of the "invitation-only"
+restriction and allow the learners to enroll in such courses.
 
 Rejected Alternatives
 *********************
@@ -110,7 +176,7 @@ Rejected Alternatives
 1. Enrollment eligibility checks in POST
 ========================================
 
-Implement an ``canEnroll`` check for a LearningPath that can determine if a
+Implement an ``canEnroll`` check for a Learning Path that can determine if a
 learner is eligible to enroll in all of the underlying courses before
 creating an enrollment.
 
@@ -122,3 +188,5 @@ flawed in other scenarios like:
   completion of other courses
 * courses are marked as "invite only" but are available via their enterprise's
   catalog ...etc.,
+* course is open during the time of Learning Path enrollment, but closes
+  before the learner completes preceeding courses.

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -164,7 +164,7 @@ If a Learning Path is composed of courses that are restricted using this flag,
 either partially (some of the courses) or fully (all the courses), it creates
 a scenario where a learner might be enrolled in a Learning Path using the
 :ref:`Enroll API <enroll-api>`, but cannot enroll into a course that is a part
-of the LearningPath.
+of the Learning Path.
 
 This limitation will be addressed in a future ADR, that could possibly introduce
 a flag on the ``LearningPath`` model allowing bypass of the "invitation-only"
@@ -184,9 +184,9 @@ While this will solve the issues where an user is enrolled in a Learning Path,
 but lacks access to the underlying courses at the time of enrollment, it is
 flawed in other scenarios like:
 
-* courses in a learning path are gated by pre-requisites like skills or
+* courses in a learning path are gated by prerequisites like skills or
   completion of other courses
 * courses are marked as "invite only" but are available via their enterprise's
   catalog ...etc.,
 * course is open during the time of Learning Path enrollment, but closes
-  before the learner completes preceeding courses.
+  before the learner completes preceding courses.

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -1,8 +1,6 @@
-#################################
 0003 Learning Path Enrollment API
 #################################
 
-******
 Status
 ******
 
@@ -16,7 +14,6 @@ Status
 
     If an ADR has Draft status and the PR is under review, you can either use the intended final status (e.g. Provisional, Accepted, etc.), or you can clarify both the current and intended status using something like the following: "Draft (=> Provisional)". Either of these options is especially useful if the merged status is not intended to be Accepted.
 
-*******
 Context
 *******
 
@@ -24,7 +21,6 @@ Learner enrollments in Learning Paths are captured in the LearningPathEnrollment
 model. In this ADR, it is enhanced with necessary fields and API to perform
 enrollments and store relevant data.
 
-********
 Decision
 ********
 
@@ -235,7 +231,7 @@ user emails, the following will be created:
 7. User model post_save signal receiver for auto enrollment
 ===========================================================
 
-Since the bulk enrollment API supports enrolling non-existant users by creating
+Since the bulk enrollment API supports enrolling non-existent users by creating
 ``LearningPathEnrollmentAllowed`` objects with just the email, there needs to be
 a mechanism to automatically enroll the users when they register.
 

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -224,6 +224,12 @@ user emails, the following will be created:
    users, and just the emails for non-existing users.
 #. A ``LearningPathEnrollment`` object for existing users.
 
+.. note::
+
+   The API currently is designed with minimal set of parameters to support
+   enrollment of learners. It should be updated to include more fields in the
+   future to accommodate extra metadata.
+
 
 7. User model post_save signal receiver for auto enrollment
 ===========================================================

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -1,0 +1,58 @@
+0003 Learning Path Enrollment API
+###########################################
+
+Status
+******
+
+**Draft**
+
+.. Standard statuses
+    - **Draft** if the decision is newly proposed and in active discussion
+    - **Provisional** if the decision is still preliminary and in experimental phase
+    - **Accepted** *(date)* once it is agreed upon
+    - **Superseded** *(date)* with a reference to its replacement if a later ADR changes or reverses the decision
+
+    If an ADR has Draft status and the PR is under review, you can either use the intended final status (e.g. Provisional, Accepted, etc.), or you can clarify both the current and intended status using something like the following: "Draft (=> Provisional)". Either of these options is especially useful if the merged status is not intended to be Accepted.
+
+Context
+*******
+
+Learner enrollments in Learning Paths are captured in the
+LearningPathEnrollment model. However, there is no API exposing an interface to
+perform operations on the model.
+
+Decision
+********
+
+We will create a new view in the `api` app to expose an API that can be called
+by other services to enroll a learner in the Learning Path.
+
++---------------------+-------------------------------------------------------+
+| API Path            | /api/v1/learning-path/<uuid:learning-path-id>/enroll/ |
++---------------------+-------------------------------------------------------+
+| Method              | POST                                                  |
++---------------------+-------------------------------------------------------+
+| Data                | username                                              |
++---------------------+-------------------------------------------------------+
+| Permissions Required| LoggedIn                                              |
++---------------------+-------------------------------------------------------+
+
+.. note:: The UUID in the URL will be replaced with a more human friendly key
+   later.
+
+
+Consequences
+************
+
+* The new API will allow external services with valid user credentials (eg.,
+  MFEs) to enroll learners in Learning Paths.
+* While access to courses can be restricted by marking them "Invitation
+  Required", there is no such flag for a Learning Path. So, any learner who
+  knows the ID of a Learning Path can enroll in it, without actaully having
+  access to any of the courses in the Learning Path. This shortcoming will have
+  be addressed in future development.
+
+Rejected Alternatives
+*********************
+
+NA

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -4,7 +4,7 @@
 Status
 ******
 
-**Draft**
+**Provisional**
 
 .. Standard statuses
     - **Draft** if the decision is newly proposed and in active discussion
@@ -65,6 +65,10 @@ Model attributes
 
 3. LearningPathEnrollmentAllowed Model
 ======================================
+
+.. warning::
+
+   The scope of this model is not finalized, so do not implement it yet.
 
 Create a new Django model called ``LearningPathEnrollmentAllowed`` to store
 records of future enrollments to specific Learning Paths. The users may or may
@@ -180,7 +184,7 @@ This API would list all the Learning Path enrollments
 * of all users, for a staff user
 
 +---------------------+-------------------------------------------------------+
-| API Path            | /api/v1/learning-path-enrollment/                     |
+| API Path            | /api/v1/enrollment/                                   |
 +---------------------+-------------------------------------------------------+
 | Methods             | GET                                                   |
 +---------------------+-------------------------------------------------------+
@@ -194,7 +198,7 @@ In order for staff to bulk enroll users into learning paths, implement the
 following API.
 
 +---------------------+-------------------------------------------------------+
-| API Path            | /api/v1/learning-path-enrollment/bulk_enroll/         |
+| API Path            | /api/v1/enrollment/bulk_enroll/                       |
 +---------------------+-------------------------------------------------------+
 | Methods             | POST                                                  |
 +---------------------+-------------------------------------------------------+

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -44,7 +44,8 @@ This API will allow learners to be enrolled in the
 | Permissions Required| LoggedIn                                              |
 +---------------------+-------------------------------------------------------+
 
-.. note:: The UUID of the learning_path_id will be replaced with a more
+.. note::
+   The UUID of the learning_path_id will be replaced with a more
    user-friendly value later.
 
 GET
@@ -69,9 +70,7 @@ POST
   Path reference by the ``learning_path_id``.
 * When ``username`` is passed and is different from the ``currentUser``, the user
   linked to ``username`` will be enrolled, if the ``currentUser`` is a **staff**
-  or **admin**.
-* For non-admin or non-staff users, when the ``currentUser`` and the user linked
-  to ``username`` are different, return a HTTP 403.
+  or **admin**. Otherwise, this will return an HTTP 403 error.
 
 DELETE
 """"""
@@ -102,7 +101,7 @@ Consequences
 * While access to courses can be restricted by marking them "Invitation
   Required", there is no such flag for a Learning Path. So, any learner who
   knows the ID of a Learning Path can enroll using the :ref:`Enroll API <enroll-api>`,
-  without actaully having access to any of the courses in the Learning Path. This
+  without having access to any of the courses in the Learning Path. This
   shortcoming will have be addressed in future development.
 
 Rejected Alternatives

--- a/docs/decisions/0003-learning-path-enrollment-api.rst
+++ b/docs/decisions/0003-learning-path-enrollment-api.rst
@@ -24,22 +24,75 @@ perform operations on the model.
 Decision
 ********
 
-We will create a new view in the `api` app to expose an API that can be called
-by other services to enroll a learner in the Learning Path.
+We will create the following views in the ``api`` app to expose an API that can be called
+by other services and MFEs.
+
+.. _enroll-api:
+
+1. Enroll API
+=============
+
+This API will allow learners to be enrolled in the
 
 +---------------------+-------------------------------------------------------+
-| API Path            | /api/v1/learning-path/<uuid:learning-path-id>/enroll/ |
+| API Path            | /api/v1/learning-path-enrollment/                     |
 +---------------------+-------------------------------------------------------+
-| Method              | POST                                                  |
+| Methods             | GET, POST, DELETE                                     |
 +---------------------+-------------------------------------------------------+
-| Data                | username                                              |
+| Data                | learning_path_id (uuid), username (OPTIONAL)          |
 +---------------------+-------------------------------------------------------+
 | Permissions Required| LoggedIn                                              |
 +---------------------+-------------------------------------------------------+
 
-.. note:: The UUID in the URL will be replaced with a more human friendly key
-   later.
+.. note:: The UUID of the learning_path_id will be replaced with a more
+   user-friendly value later.
 
+GET
+"""
+
+**Corresponding User Action:** Fetch my enrollment
+
+* The data fields ``learning_path_id`` and ``username`` will be passed as query
+  parameters.
+* Return the LearningPathEnrollment object if the logged-in user is enrolled in the
+  specified learning path. Otherwise returns a HTTP 404.
+* When the ``username`` is present, returns all the enrollments in a learning
+  path if the ``currentUser`` is a **staff** or **admin** user.
+
+
+POST
+""""
+
+**Corresponding User Action:** Enroll
+
+* When ``username`` is absent, enrolls the ``currentUser`` in the Learning
+  Path reference by the ``learning_path_id``.
+* When ``username`` is passed and is different from the ``currentUser``, the user
+  linked to ``username`` will be enrolled, if the ``currentUser`` is a **staff**
+  or **admin**.
+* For non-admin or non-staff users, when the ``currentUser`` and the user linked
+  to ``username`` are different, return a HTTP 403.
+
+DELETE
+""""""
+
+**Corresponding User Action:** Unenroll
+
+This will follow the same permission logic as the **POST** request allowing
+both self-unenrollment and staff-unenrollment.
+
+
+2. LearningPathEnrollment Model
+===============================
+
+Add a new ``enrolled_by`` as a ``ForeignKey`` field to the
+``LearningPathEnrollment`` model that will store the user who created the
+enrollment. This will allow for distinguishing between self and staff
+enrollments.
+
+Since it is already a subclass of the ``TimeStatmpedModel``, we don't need to
+introduce a ``enrolled_at`` field and can instead depend on the inherited ``created``
+field.
 
 Consequences
 ************
@@ -48,11 +101,24 @@ Consequences
   MFEs) to enroll learners in Learning Paths.
 * While access to courses can be restricted by marking them "Invitation
   Required", there is no such flag for a Learning Path. So, any learner who
-  knows the ID of a Learning Path can enroll in it, without actaully having
-  access to any of the courses in the Learning Path. This shortcoming will have
-  be addressed in future development.
+  knows the ID of a Learning Path can enroll using the :ref:`Enroll API <enroll-api>`,
+  without actaully having access to any of the courses in the Learning Path. This
+  shortcoming will have be addressed in future development.
 
 Rejected Alternatives
 *********************
 
-NA
+1. Enrollment eligibility checks in POST
+========================================
+
+Implement an ``canEnroll`` check for a LearningPath that can determine if a
+learner is eligible to enroll in all of the underlying courses before
+creating an enrollment.
+
+While this will solve the issues where an user is enrolled in a Learning Path,
+but lacks access to the underlying courses at the time of enrollment, it is
+flawed in other scenarios like:
+* courses in a learning path are gated by pre-requisites like skills or
+  completion of other courses
+* courses are marked as "invite only" but are available via their enterprise's
+  catalog ...etc.,


### PR DESCRIPTION
The PR adds an ADR to implement an API to create Learning Path Enrollments.

Internal Ref: https://tasks.opencraft.com/browse/BB-9504

A more readable rendered version of the ADR is available [here](https://github.com/open-craft/learning-paths-plugin/blob/tecoholic/BB-9504-learning-path-enrollment-api/docs/decisions/0003-learning-path-enrollment-api.rst) in the PR branch.
